### PR TITLE
API is deprecated

### DIFF
--- a/hints/k8sSingle.md
+++ b/hints/k8sSingle.md
@@ -4,7 +4,7 @@
 
 1. Run single container app in your K8s cluster
 ```
-kubectl run meinnginx --image=nginx
+kubectl run meinnginx --generator=run-pod/v1 --image=nginx
 ```
 2. See what you got
 ```


### PR DESCRIPTION
kubectl run --generator=deployment/apps.v1 is DEPRECATED and will be removed in a future version. Use kubectl run --generator=run-pod/v1 or kubectl create instead.